### PR TITLE
Fix flaky test.

### DIFF
--- a/jest-common/src/main/java/io/searchbox/indices/Rollover.java
+++ b/jest-common/src/main/java/io/searchbox/indices/Rollover.java
@@ -5,6 +5,7 @@ import io.searchbox.action.GenericResultAbstractAction;
 import io.searchbox.client.config.ElasticsearchVersion;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class Rollover extends GenericResultAbstractAction {
@@ -15,12 +16,12 @@ public class Rollover extends GenericResultAbstractAction {
         super(builder);
 
         this.indexName = builder.index;
-        Map<String, Object> rolloverConditions = new HashMap<>();
-        if (builder.conditions != null) {
-            rolloverConditions.put("conditions", builder.conditions);
-        }
+        Map<String, Object> rolloverConditions = new LinkedHashMap<>();
         if (builder.settings != null) {
             rolloverConditions.put("settings", builder.settings);
+        }
+        if (builder.conditions != null) {
+            rolloverConditions.put("conditions", builder.conditions);
         }
         this.payload = rolloverConditions;
 

--- a/jest-common/src/test/java/io/searchbox/indices/RolloverTest.java
+++ b/jest-common/src/test/java/io/searchbox/indices/RolloverTest.java
@@ -5,6 +5,7 @@ import io.searchbox.client.config.ElasticsearchVersion;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.junit.Test;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -12,14 +13,13 @@ import static org.junit.Assert.assertNotEquals;
 
 public class RolloverTest {
 
-    Map<String, Object> rolloverConditions = new MapBuilder<String, Object>()
-                    .put("max_docs", "10000")
-                    .put("max_age", "1d")
-                    .immutableMap();
-    Map<String, Object> rolloverSettings = new MapBuilder<String, Object>()
-            .put("index.number_of_shards", "2")
-            .immutableMap();
-
+    LinkedHashMap<String, Object> rolloverConditions = new LinkedHashMap<>();
+    LinkedHashMap<String, Object> rolloverSettings = new LinkedHashMap<>();
+    {
+        rolloverConditions.put("max_age", "1d");
+        rolloverConditions.put("max_docs", "10000");
+        rolloverSettings.put("index.number_of_shards", "2");
+    }
 
     @Test
     public void testBasicUriGeneration() {


### PR DESCRIPTION
## Description
Flaky tests can nondeterministically pass or fail. I found that **testBasicUriGeneration** and **testBasicUriWithSettingsGeneration** may fail because hashmap is stored in a disordered order. Actually, LinkedHashMap can replace HashMap in order to ensure the orderliness of key-value pairs.

## Reproduction
Following commands can be used to reproduce:
`cd Jest`
`mvn clean install -DskipTests -pl jest-common -am`
In regular runs (successful):
`mvn -pl jest-common test -Dtest=io.searchbox.indices.RolloverTest#testBasicUriGeneration`
`mvn -pl jest-common test -Dtest=io.searchbox.indices.RolloverTest#testBasicUriWithSettingsGeneration`
With NonDex tool (failed):
`mvn -pl jest-common edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=io.searchbox.indices.RolloverTest#testBasicUriGeneration -DnondexRuns=10`
`mvn -pl jest-common edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=io.searchbox.indices.RolloverTest#testBasicUriWithSettingsGeneration -DnondexRuns=10`

## Result
These two tests can pass whether in regular runs or with [NonDex tool](https://github.com/TestingResearchIllinois/NonDex).